### PR TITLE
deps: freeze vite-plugin-css-injected-by-js at 3.3.1 due to breaking change in 3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 			],
 			"dependencies": {
 				"magic-string": "^0.30.10",
-				"vite-plugin-css-injected-by-js": "^3.3.0"
+				"vite-plugin-css-injected-by-js": "3.3.1"
 			},
 			"devDependencies": {
 				"@rushstack/eslint-patch": "^1.3.3",
@@ -4661,9 +4661,9 @@
 			}
 		},
 		"node_modules/vite-plugin-css-injected-by-js": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.3.0.tgz",
-			"integrity": "sha512-xG+jyHNCmUqi/TXp6q88wTJGeAOrNLSyUUTp4qEQ9QZLGcHWQQsCsSSKa59rPMQr8sOzfzmWDd8enGqfH/dBew==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.3.1.tgz",
+			"integrity": "sha512-PjM/X45DR3/V1K1fTRs8HtZHEQ55kIfdrn+dzaqNBFrOYO073SeSNCxp4j7gSYhV9NffVHaEnOL4myoko0ePAg==",
 			"peerDependencies": {
 				"vite": ">2.0.0-0"
 			}
@@ -4888,7 +4888,7 @@
 				"npm-run-all2": "^6.1.1",
 				"types-mediawiki": "^1.4.0",
 				"typescript": "~5.2.0",
-				"vite": "^4.5.2",
+				"vite": "^4.5.3",
 				"vite-plugin-inspect": "^0.8.4",
 				"vue-tsc": "^1.8.19"
 			}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	},
 	"dependencies": {
 		"magic-string": "^0.30.10",
-		"vite-plugin-css-injected-by-js": "^3.3.0"
+		"vite-plugin-css-injected-by-js": "3.3.1"
 	},
 	"devDependencies": {
 		"@rushstack/eslint-patch": "^1.3.3",


### PR DESCRIPTION
See marco-prontera/vite-plugin-css-injected-by-js#134